### PR TITLE
Various typo fixes

### DIFF
--- a/Data/Stag.pm
+++ b/Data/Stag.pm
@@ -220,7 +220,7 @@ __END__
 =head1 DESCRIPTION
 
 This module is for manipulating data as hierarchical tag/value
-pairs (Structured TAGs or Simple Tree AGgreggates). These
+pairs (Structured TAGs or Simple Tree AGgregates). These
 datastructures can be represented as nested arrays, which have the
 advantage of being native to perl. A simple example is shown below:
 
@@ -259,7 +259,7 @@ Advanced querying is performed by passing functions, for example:
                      sub {shift->sget('family_name') =~ /^A/});
 
 One of the things that marks this module out against other XML modules
-is this emphasis on a B<functional> approach as an obect-oriented or
+is this emphasis on a B<functional> approach as an object-oriented or
 procedural approach.
 
 For full information on the stag project, see
@@ -1559,9 +1559,9 @@ returns all terminal children of current node
 
 does a relational style inner join - see previous example in this doc
 
-key can either be a single node name that must be shared (analagous to
+key can either be a single node name that must be shared (analogous to
 SQL INNER JOIN .. USING), or a key1=key2 equivalence relation
-(analagous to SQL INNER JOIN ... ON)
+(analogous to SQL INNER JOIN ... ON)
 
 =head3 qmatch (qm)
 
@@ -1908,7 +1908,7 @@ parses a file and fires events (e.g. sxpr to xml)
 
 =item stag-query.pl
 
-aggregare queries
+aggregate queries
 
 =item stag-split.pl
 

--- a/Data/Stag/Writer.pm
+++ b/Data/Stag/Writer.pm
@@ -93,7 +93,7 @@ to be used by classes that subclass this one
 
        Title: writef
 
-As write, analagous to printf
+As write, analogous to printf
 
 
 =cut

--- a/README
+++ b/README
@@ -28,7 +28,7 @@ SYNOPSIS
 
 DESCRIPTION
     This module is for manipulating data as hierarchical tag/value pairs
-    (Structured TAGs or Simple Tree AGgreggates). These datastructures can
+    (Structured TAGs or Simple Tree AGgregates). These datastructures can
     be represented as nested arrays, which have the advantage of being
     native to perl. A simple example is shown below:
 
@@ -67,7 +67,7 @@ DESCRIPTION
                          sub {shift->sget('family_name') =~ /^A/});
 
     One of the things that marks this module out against other XML modules
-    is this emphasis on a functional approach as an obect-oriented or
+    is this emphasis on a functional approach as an object-oriented or
     procedural approach.
 
   PROCEDURAL VS OBJECT-ORIENTED USAGE
@@ -1188,8 +1188,8 @@ STAG METHODS
 
     does a relational style inner join - see previous example in this doc
 
-    key can either be a single node name that must be shared (analagous to
-    SQL INNER JOIN .. USING), or a key1=key2 equivalence relation (analagous
+    key can either be a single node name that must be shared (analogous to
+    SQL INNER JOIN .. USING), or a key1=key2 equivalence relation (analogous
     to SQL INNER JOIN ... ON)
 
    qmatch (qm)
@@ -1451,7 +1451,7 @@ STAG SCRIPTS
         parses a file and fires events (e.g. sxpr to xml)
 
     stag-query.pl
-        aggregare queries
+        aggregate queries
 
     stag-split.pl
         splits a stag file (xml, itext, sxpr) into multiple files

--- a/homepage/script-docs/stag-query.html
+++ b/homepage/script-docs/stag-query.html
@@ -21,7 +21,7 @@
 <HR>
 <P>
 <H1><A NAME="name">NAME</A></H1>
-<P>stag-query.pl - aggregare queries</P>
+<P>stag-query.pl - aggregate queries</P>
 <P>
 <HR>
 <H1><A NAME="synopsis">SYNOPSIS</A></H1>

--- a/homepage/script-list.html
+++ b/homepage/script-list.html
@@ -283,7 +283,7 @@ and feeds the events into a handler/writer class</pre>
     <h3>
       <a href="script-docs/stag-query.html">stag-query.pl</a>
     </h3>
-    <div class="summary">aggregare queries</div>
+    <div class="summary">aggregate queries</div>
     <div class="codeblock">
         <pre>
 stag-query.pl avg person/age file.xml

--- a/scripts/stag-query.pl
+++ b/scripts/stag-query.pl
@@ -95,7 +95,7 @@ __END__
 
 =head1 NAME 
 
-stag-query - aggregare queries
+stag-query - aggregate queries
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This fixes the spelling of "Simple Tree AGgreggates" to "AGgregates" in the explanation of the acronym STAG. A few other typos that I noticed while doing this were fixed as well.
